### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+    tags: '*'
+
+jobs:
+  runtimes-build-and-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install prerequisites
+        run: |
+          sudo apt update
+          sudo apt -y install cpanminus
+          cpanm --sudo --notest YAML::PP
+
+      - uses: actions/checkout@v2
+
+      - name: Build all runtimes
+        run: make build
+
+      - name: Run tests
+        run: make testv
+        continue-on-error: true

--- a/bin/build.pl
+++ b/bin/build.pl
@@ -328,7 +328,7 @@ sub build {
         }
         my $mount_options = join ' ', map { "-v$_" } @mounts;
         my $cmd = sprintf
-            'docker run -it --rm --user %s'
+            'docker run --rm --user %s'
             . ' --env HOME=%s --env VERSION=%s --env SOURCE=%s --env LIBNAME=%s '
             . $mount_options
             . " $prefix/%s /buildutils/%s",


### PR DESCRIPTION
* Add GitHub Actions CI script.
* Run job on push to PR or master branch.
* Remove interactive (`-it`) switch from `docker run` command, to avoid errors like `the input device is not a TTY`
* Set test step to [`continue-on-error`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error); there were four tests failures ([raw logs](https://pipelines.actions.githubusercontent.com/Nst2SEGSqtwjvWpWdjIE6MsjHugxoA2SMJby0N6ackOKblDQfp/_apis/pipelines/1/runs/12/signedlogcontent/3?urlExpires=2020-08-14T02%3A03%3A59.1977128Z&urlSigningMethod=HMACV1&urlSignature=CYkbEHFoh0SPqw7rX%2FlKI5JF4vzEmczT6P%2FzGjux7Ak%3D)). When they get fixed, we can remove `continue-on-error: true` line.

Example run: https://github.com/am11/yaml-runtimes/runs/983024052?check_suite_focus=true.