### PR TITLE
updated NimYAML to 0.16.0

### DIFF
--- a/docker/nim/alpine-builder.dockerfile
+++ b/docker/nim/alpine-builder.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15
+FROM alpine:3.15.0
 
 RUN apk update && \
   apk add \

--- a/docker/nim/alpine-builder.dockerfile
+++ b/docker/nim/alpine-builder.dockerfile
@@ -1,21 +1,7 @@
-FROM alpine:3.10.2
+FROM alpine:3.15
 
 RUN apk update && \
   apk add \
-    less \
-    vim \
-    wget \
-    musl \
-    make \
     g++ \
-    m4 \
+    nim \
   && true
-
-RUN mkdir /nim && cd /nim && \
-  wget https://nim-lang.org/download/nim-1.6.0.tar.xz && \
-  tar xvf nim-1.6.0.tar.xz && \
-  cd nim-1.6.0/ && \
-  sh build.sh && \
-  bin/nim c koch && \
-  ./koch tools && \
-  ln -s /nim/nim-1.6.0/bin/nim /bin/nim


### PR DESCRIPTION
This updates NimYAML to current 0.16.0 release.

 * uses alpine:edge which provides a decently up-to-date `nim` package, dropping the requirement of manually installing nim. Sadly the package is not contained in any stable release yet. Testing showed that this does not lead to errors during consolidation into the apline-runtime-static image.
 * simplifies the testing code; `+STR`/`-STR` are now provided by NimYAML