### PR TITLE
bump NimYAML to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Type `make list` to see the following list:
 | js-jsyaml         | Javascript | [js-yaml](https://github.com/nodeca/js-yaml) | 4.1.0    | node    |
 | js-yaml           | Javascript | [yaml](https://github.com/eemeli/yaml) | 2.0.0-10 | node    |
 | lua-lyaml         | Lua        | [lyaml](https://github.com/gvvaughan/lyaml) | 6.2.7    | lua     |
-| nim-nimyaml       | Nim        | [NimYAML](https://github.com/flyx/NimYAML) | 0.16.0   | static  |
+| nim-nimyaml       | Nim        | [NimYAML](https://github.com/flyx/NimYAML) | 1.1.0   | static  |
 | perl-pp           | Perl       | [YAML::PP](https://metacpan.org/release/YAML-PP) | 0.031    | perl    |
 | perl-pplibyaml    | Perl       | [YAML::PP::LibYAML](https://metacpan.org/release/YAML-PP-LibYAML) | 0.005    | perl    |
 | perl-refparser    | Perl       | [Generated RefParser](https://metacpan.org/release/YAML-Parser) | 0.0.5    | perl    |

--- a/list.yaml
+++ b/list.yaml
@@ -173,8 +173,8 @@ libraries:
     name: NimYAML
     homepage: https://github.com/flyx/NimYAML
     lang: Nim
-    source: https://github.com/flyx/NimYAML/archive/v0.16.0.tar.gz
-    version: 0.16.0
+    source: https://github.com/flyx/NimYAML/archive/v1.1.0.tar.gz
+    version: 1.1.0
     build-script: nimyaml-build.sh
     tests: [event]
     build-image: nim


### PR DESCRIPTION
I don't have a working docker setup to test this due to being on M1, but NimYAML didn't drop support for the Nim version used in the current docker image so I *hope* this just works :)