### PR TITLE
rapidyaml: bump version, split to event+tree tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,11 @@ PERL =    perl-pp perl-pplibyaml perl-syck perl-tiny perl-xs perl-yaml perl-refp
 PYTHON =  py-pyyaml py-ruamel
 #RAKUDO =  raku-yamlish
 RUBY =    ruby-psych
-STATIC =  c-libfyaml c-libyaml cpp-rapidyaml cpp-yamlcpp go-yaml rust-yamlrust
+STATIC =  c-libfyaml c-libyaml cpp-rapidyaml-engine cpp-rapidyaml-testsuite cpp-rapidyaml-tree cpp-yamlcpp go-yaml rust-yamlrust
 
 build: $(DOTNET) $(HASKELL) $(LUA) $(NIM) $(NODE) $(PERL) $(PYTHON) $(RUBY) $(STATIC)
+
+cpp-rapidyaml: cpp-rapidyaml-engine cpp-rapidyaml-tree
 
 runtime-all:
 	docker build -t yamlio/alpine-runtime-all  -f docker/Dockerfile .

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Type `make list` to see the following list:
 | ----------------- | ---------- | ------------------ | -------- | ------- |
 | c-libfyaml        | C          | [libfyaml](https://github.com/pantoniou/libfyaml) | 0.7.12   | static  |
 | c-libyaml         | C          | [libyaml](https://github.com/yaml/libyaml) | 0.2.5    | static  |
-| cpp-rapidyaml     | C++        | [rapidyaml](https://github.com/biojppm/rapidyaml) | 0.4.0    | static  |
+| cpp-rapidyaml     | C++        | [rapidyaml](https://github.com/biojppm/rapidyaml) | 0.15.2    | static  |
 | cpp-yamlcpp       | C++        | [yaml-cpp](https://github.com/jbeder/yaml-cpp) | 0.8.0    | static  |
 | dotnet-yamldotnet | C#         | [YamlDotNet](https://github.com/aaubry/YamlDotNet) | 11.2.1   | dotnet  |
 | go-yaml           | Go         | [go-yaml](https://github.com/go-yaml/yaml) | v2       | static  |

--- a/docker/static/testers/cpp-rapidyaml-engine-event
+++ b/docker/static/testers/cpp-rapidyaml-engine-event
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# ints handler:
+# YAML -> rapidyaml int events -> test suite events
+
+if [ ! -t 0 ]; then
+    # if input comes from stdin, ryml wants a `-`
+    ryml-yaml-events ts_ints $@ -
+else
+    ryml-yaml-events ts_ints $@
+fi

--- a/docker/static/testers/cpp-rapidyaml-event
+++ b/docker/static/testers/cpp-rapidyaml-event
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if [ ! -t 0 ]; then
-    # if input comes from stdin, ryml wants a `-`
-    ryml-yaml-events $@ -
-else
-    ryml-yaml-events $@
-fi

--- a/docker/static/testers/cpp-rapidyaml-tree-event
+++ b/docker/static/testers/cpp-rapidyaml-tree-event
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# tree handler:
+# YAML -> rapidyaml tree -> test suite events
+
+if [ ! -t 0 ]; then
+    # if input comes from stdin, ryml wants a `-`
+    ryml-yaml-events ts_tree $@ -
+else
+    ryml-yaml-events ts_tree $@
+fi

--- a/docker/static/testers/cpp-rapidyaml-tree-json
+++ b/docker/static/testers/cpp-rapidyaml-tree-json
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# tree handler:
+# YAML -> rapidyaml tree -> YAML/JSON
+
+#  -h,--help              print this message
+#  -e [N],--reserve [N]   reserve tree size before parsing (default: N=%d):
+#                         0=do not reserve
+#                         1=reserve by estimating size
+#                         all other values=reserve with value
+#  -r,--resolve           resolve references (default: %s)
+#  -k,--keep-refs         keep refs and anchors after resolving (default: %s)
+#  -p,--print-tree        print parsed rapidyaml tree before emitting (default: %s)
+#  -q,--quiet             do not emit (default: %s)
+#  -j,--json              emit json instead of yaml (default: %s)
+#  -s,--string            emit to string before dumping to stdout/file.
+#                         otherwise, emit directly to stdout (default: %s)
+#  -t,--timed             time sections (print timings to stderr) (default: %s)
+#  -o,--output <filename> emit to the given filename (default: %s)
+
+if [ ! -t 0 ]; then
+    # if input comes from stdin, ryml wants a `-`
+    ryml-parse-emit --json --reserve 1 --resolve $@ -
+else
+    ryml-parse-emit --json --reserve 1 --resolve $@
+fi

--- a/docker/static/testers/cpp-rapidyaml-tree-yaml
+++ b/docker/static/testers/cpp-rapidyaml-tree-yaml
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# tree handler:
+# YAML -> rapidyaml tree -> YAML/JSON
+
+#  -h,--help              print this message
+#  -e [N],--reserve [N]   reserve tree size before parsing (default: N=%d):
+#                         0=do not reserve
+#                         1=reserve by estimating size
+#                         all other values=reserve with value
+#  -r,--resolve           resolve references (default: %s)
+#  -k,--keep-refs         keep refs and anchors after resolving (default: %s)
+#  -p,--print-tree        print parsed rapidyaml tree before emitting (default: %s)
+#  -q,--quiet             do not emit (default: %s)
+#  -j,--json              emit json instead of yaml (default: %s)
+#  -s,--string            emit to string before dumping to stdout/file.
+#                         otherwise, emit directly to stdout (default: %s)
+#  -t,--timed             time sections (print timings to stderr) (default: %s)
+#  -o,--output <filename> emit to the given filename (default: %s)
+
+if [ ! -t 0 ]; then
+    # if input comes from stdin, ryml wants a `-`
+    ryml-parse-emit --reserve 1 --resolve $@ -
+else
+    ryml-parse-emit --reserve 1 --resolve $@
+fi

--- a/docker/static/utils/cpp-rapidyaml-build.sh
+++ b/docker/static/utils/cpp-rapidyaml-build.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-set -x
+set -xe
 cd /tmp
 
 cp $SOURCE .
@@ -9,9 +9,18 @@ cd rapidyaml-$VERSION-src
 
 cmake --version
 cmake -S . -B ./build \
-  -DRYML_BUILD_TOOLS=ON -DRYML_WITH_TAB_TOKENS=ON \
-  -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Debug
+  -DRYML_BUILD_TOOLS=ON \
+  -DRYML_WITH_TAB_TOKENS=ON \
+  -DRYML_DEFAULT_CALLBACK_USES_EXCEPTIONS=ON \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DCMAKE_BUILD_TYPE=Release
 cmake --build ./build -j --target ryml-yaml-events
+cmake --build ./build -j --target ryml-parse-emit
+
 file=$(find ./build -name 'ryml-yaml-events*' -type f)
+mkdir -p /build/bin/
 cp -fav $file /build/bin/ryml-yaml-events
 
+file=$(find ./build -name 'ryml-parse-emit*' -type f)
+mkdir -p /build/bin/
+cp -fav $file /build/bin/ryml-parse-emit

--- a/list.yaml
+++ b/list.yaml
@@ -1,5 +1,6 @@
 ---
 
+
 runtimes:
 
 - &all
@@ -44,6 +45,14 @@ runtimes:
 - &static
   runtime: static
 
+
+.rapidyaml: &rapidyaml
+    homepage: https://github.com/biojppm/rapidyaml
+    lang: C++
+    version: 0.15.2
+    source: https://github.com/biojppm/rapidyaml/releases/download/v0.15.2/rapidyaml-0.15.2-src.tgz
+
+
 libraries:
 
   c-libyaml:
@@ -76,15 +85,19 @@ libraries:
     build-script: go-yaml-build.sh
     tests: [json]
 
-  cpp-rapidyaml:
+  cpp-rapidyaml-engine:  # YAML->ints->testsuite. This should be the default
     <<: *static
-    name: rapidyaml
-    homepage: https://github.com/biojppm/rapidyaml
-    lang: C++
-    version: 0.4.0
-    source: https://github.com/biojppm/rapidyaml/releases/download/v0.4.0/rapidyaml-0.4.0-src.tgz
+    <<: *rapidyaml
+    name: rapidyaml-engine
     build-script: cpp-rapidyaml-build.sh
     tests: [event]
+  cpp-rapidyaml-tree:  # YAML->tree->testsuite / YAML / JSON. Does not accept container keys.
+    <<: *static
+    <<: *rapidyaml
+    build-script: cpp-rapidyaml-build.sh
+    name: rapidyaml-tree
+    build-script: ls
+    tests: [event, yaml, json]
 
   cpp-yamlcpp:
     <<: *static


### PR DESCRIPTION
Updates rapidyaml to the latest version.  Also adds a fully compliant event emitter which does not require a rapidyaml tree. 
