### PR TITLE
JS yaml: Disable resolveKnownTags for JSON tests

### DIFF
--- a/docker/node/testers/js-yaml-json
+++ b/docker/node/testers/js-yaml-json
@@ -4,8 +4,10 @@ const fs = require('fs')
 const YAML = require('yaml')
 
 const src = fs.readFileSync('/dev/stdin').toString()
-const docs = YAML.parseAllDocuments(src).map(doc => {
-  if (doc.errors.length !== 0) throw doc.errors[0]
-  return JSON.stringify(doc.toJSON(), null, 2) + '\n'
-})
+const docs = YAML.parseAllDocuments(src, { resolveKnownTags: false }).map(
+  doc => {
+    if (doc.errors.length !== 0) throw doc.errors[0]
+    return JSON.stringify(doc.toJSON(), null, 2) + '\n'
+  }
+)
 fs.writeSync(1, docs.join(''))


### PR DESCRIPTION
By default, `yaml` auto-detects explicit YAML 1.1 tags, which are not included in the YAML 1.2 schemas. This means that the results of parsing `!!binary`, `!!omap`, `!!set`, and others differs from the expected results of tests 565N, 2XXW, and J7PZ.

To keep the library to only 1.2 tags, let's set `resolveKnownTags: false` for the JSON tests.